### PR TITLE
Precompile Masonry JS

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Www::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  # config.assets.precompile += %w( search.js )
+  config.assets.precompile += %w( imagesloaded.pkgd.min.js masonry.pkgd.min.js classie.js AnimOnScroll.js layout.js )
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
The JS in the section pages (Masonry.js related) needed to be precompiled, and I forgot.
