### PR TITLE
Clean up routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Www::Application.routes.draw do
   root :to => 'root#index'
   
-  [:blog, :news, :jobs, :team, :case_studies, :courses, :creative_works, :procurement, :organizations, :nodes,
+  [:blog, :news, :jobs, :team, :case_studies, :courses, :creative_works, :procurement, :start_ups, :nodes,
     :consultation_responses, :guides].each do |section|
     section_slug = section.to_s.dasherize
     get "#{section_slug}", as: "#{section}_section", to: "root##{section}_list", :section => section_slug
@@ -11,16 +11,11 @@ Www::Application.routes.draw do
     get "#{section_slug}/:slug/badge", as: "#{section}_badge", to: 'root#badge', :section => section_slug
   end  
   
-  [:culture, :our_space, :dashboards, :membership, :certificates, :pg_certificate, :lunchtime_lectures, :newsroom, :virtual_tour].each do |page|
-    slug = page.to_s.dasherize
-    get "#{slug}", as: "page", to: 'root#page', slug: slug
-  end
-  
   [:about, :get_involved, :learning, :whats_happening, :news].each do |section|
     slug = section.to_s.dasherize
     get "#{slug}", as: "#{section}_section", to: 'root#section', section: slug 
   end
   
-  match "start-ups", to: 'root#section', as: "organizations_section", section: "organizations"
+  get ":slug", as: "page", to: 'root#page'
 
 end


### PR DESCRIPTION
This cleans up the routes a bit, so we don't have to specify all content pages in an array, because that was silly.
