### PR TITLE
Cache *everything* for 3 hours

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,12 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery
   
+  before_filter :cache_control
+  
+  def cache_control
+    expires_in 3.hours
+  end
+  
   def content_api
     content_api ||= GdsApi::ContentApi.new(
       Plek.current.find("contentapi"),


### PR DESCRIPTION
This is a particularly stupid caching strategy, but for now it will do us just fine. This will tell Varnish that it's allowed to cache the app responses; the default from Rails was to disable it.
