### PR TITLE
commenting out the thing that stops nav working in iPhone

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,4 +19,4 @@ $('a[data-toggle=dropdown]').click(function() {
 	if ($(this).next('.dropdown-menu').css('display') == "block") {
 		window.location.href = this.href;
 	}
-})
+});

--- a/app/assets/javascripts/bootstrap/bootstrap-dropdown.js
+++ b/app/assets/javascripts/bootstrap/bootstrap-dropdown.js
@@ -52,10 +52,10 @@
       clearMenus()
 
       if (!isActive) {
-        if ('ontouchstart' in document.documentElement) {
+//        if ('ontouchstart' in document.documentElement) {
           // if mobile we we use a backdrop because click events don't delegate
-          $('<div class="dropdown-backdrop"/>').insertBefore($(this)).on('click', clearMenus)
-        }
+//          $('<div class="dropdown-backdrop"/>').insertBefore($(this)).on('click', clearMenus)
+//        }
         $parent.toggleClass('open')
       }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
                 <% menus.each_index do |i| %>
                     <% menu = menus[i] %>
                     <li class="dropdown<%= ' last' if i == menus.length - 1 %>">
-                        <a href="<%= menu['link'] %>" <% if menu['items'] %> data-toggle="dropdown" <% end %>>
+                        <a href="<%= menu['link'] %>" <% if menu['items'] %> data-target="#" data-toggle="dropdown" <% end %>>
                             <%= menu['title'] %>
                             <% if menu['items'] %>
                              <b class="caret"></b>


### PR DESCRIPTION
This is tested in emulation. It comments out some bootstrap code that is specifically designed for mobile devices, in order to enable you to collapse the menus once you've opened them up. However, you don't _want_ the menus to collapse after opening, so I think commenting this out is reasonably safe.
