### PR TITLE
Fix comment metadata on mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -116,3 +116,19 @@
     }
   }
 }
+
+@media (max-width: 767px) {
+  #juvia_comments {
+    .juvia-comment {
+      .juvia-author {
+        padding-bottom: 0;
+      }
+      .juvia-creation-date {
+        position: relative;
+        left: 10px;
+        top: 0;
+        padding: 5px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
The comment metadata (name, date posted etc) looks weird on mobile, so here's a few fixes.
