### PR TITLE
Check for precompiled assets in Jenkins

### DIFF
--- a/config/initializers/jenkins.rb
+++ b/config/initializers/jenkins.rb
@@ -1,0 +1,7 @@
+# Configure asset pipeline if we're in CI, so build fails if asset pipeline isn't configured correctly
+if ENV['JENKINS']
+  Www::Application.configure do
+    config.assets.compile = false
+    config.assets.digest = true
+  end
+end


### PR DESCRIPTION
I've added an initializer that sets things up so Rails explodes if assets aren't precompiled if JENKINS=true is set in the env. This should stop any fail being deployed to live in future.
