### PR TITLE
Styling tweaks

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1175,6 +1175,16 @@ hr {
     h2, h3 {
       clear: none;
     }
+    
+    .pull-right {
+      margin-left: 10px;
+      margin-bottom: 15px;
+    }
+    
+    .pull-left {
+      margin-right: 10px;
+      margin-bottom: 15px;
+    }
 
 }
 


### PR DESCRIPTION
This page - http://theodi.org/contact looks weird because headers are set to `clear: both` in the CSS, so I've overridden this for stuff in articles. Have added a bit of a margin to `pull-left` and `pull-right` classes for good measure.
