### PR TITLE
Change `upcoming_event?` helper to check against datetime

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,7 +59,7 @@ module ApplicationHelper
   end
   
   def upcoming_event?
-    @publication.end_date.to_date > DateTime.now
+    @publication.end_date.to_datetime > DateTime.now
   end
 
   def country(iso_code)


### PR DESCRIPTION
So the livestream shows on the day of the event (which is kinda the point)
