### PR TITLE
Fix Course Instance title

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -271,6 +271,9 @@ class RootController < ApplicationController
     @course = fetch_article(@publication.course, params[:edition], "courses", false)
     @trainers = @publication.details['trainers'] ? @publication.details['trainers'].map { |t| fetch_article(t, nil, "people", false) unless t == "" }.reject{|p| p.nil?} : []
     @title = @course.title + " - " + DateTime.parse(@publication.date).strftime("%A %d %B %Y")
+    
+    content_for :page_title, @title
+    
     respond_to do |format|
       format.html do
         render "content/course_instance"


### PR DESCRIPTION
The Course Instance titles were getting trainer names appended, so I've added an extra parameter to the `fetch_article` method which disables the `page_title` `content_for` block being set, as it appends, rather than sets.

I think this whole thing needs cleaning up a bit, but this fixes the immediate problem.
