### PR TITLE
Generate event URLs from event_type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::Base
     url_map = {
       "open-data-challenge-series" => "challenge-series"
     }
-    x = event.tag_ids.first || "event"
+    x = event.event_type || "event"
     url_map[x] || x
   end
   helper_method :event_type


### PR DESCRIPTION
Because we now have roles in the tags, so it's not a good idea to generate them from the tag_id list.
