### PR TITLE
Fix course instance previews

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -302,7 +302,7 @@ class RootController < ApplicationController
     instance = content_api.course_instance(date.strftime("%Y-%m-%d"), params[:slug], params[:edition])
     
     @publication = PublicationPresenter.new(instance)
-    @course = fetch_article(@publication.course, params[:edition], "courses", false)
+    @course = fetch_article(@publication.course, nil, "courses", false)
     @trainers = @publication.details['trainers'] ? @publication.details['trainers'].map { |t| fetch_article(t, nil, "people", false) unless t == "" }.reject{|p| p.nil?} : []
     @title = @course.title + " - " + DateTime.parse(@publication.date).strftime("%A %d %B %Y")
     


### PR DESCRIPTION
When we were getting the course for a course instance, we were passing the edition param in, which at best might have caused old content to show up in the preview, and at worse cause complete carnage and breakage. A quick fix sorts this.
