### PR TITLE
Pin rack-google-analytics version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dotenv-rails'
 gem 'foreman'
 gem 'thin'
 
-gem 'rack-google-analytics'
+gem 'rack-google-analytics', '0.14.0'
 
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
-    rack-google-analytics (1.0.0)
+    rack-google-analytics (0.14.0)
       actionpack
       activesupport
     rack-ssl (1.3.3)
@@ -240,7 +240,7 @@ DEPENDENCIES
   odlifier!
   plek (= 1.5.0)
   pry
-  rack-google-analytics
+  rack-google-analytics (= 0.14.0)
   rails (~> 3.2.14)
   sass-rails (~> 3.2.3)
   simplecov-rcov


### PR DESCRIPTION
Bimble upgraded the Rack Google Analytics version to 1.0, which uses the new `analytics.js` code, and we still have some sites on
odi.org subdomains that use the old code. My guess is because we're using `ga.js` AND `analytics.js` on the same account, GA is on
ly counting those that use `ga.js`.

We should probably also discount any views we get for Google drive too, as those are mainly internal.
