### PR TITLE
Get the web_url of the module_image

### DIFF
--- a/app/views/module/_module_image.html.erb
+++ b/app/views/module/_module_image.html.erb
@@ -1,5 +1,5 @@
 <% if publication.details.module_image %>
   <div class="image">
-    <img src="<%= data_uri(publication.details.module_image) %>" class="background-image" />
+    <img src="<%= data_uri(publication.details.module_image.web_url) %>" class="background-image" />
   </div>
 <% end %>


### PR DESCRIPTION
To get them working with the new content api. Before, `module_image` was a string, now it's a hash with lots more detail. This is
probably a more elegant way of doing it, hence why I'm fixing it here and not in content API
