### PR TITLE
Update tags list

### DIFF
--- a/app/views/list/tags.html.erb
+++ b/app/views/list/tags.html.erb
@@ -13,7 +13,7 @@
     <li>
     <article class="tag-result">
       <h2><%= link_to(artefact.title, artefact.web_url ) %></h2>
-      <p>
+      <p class="description">
       <%= truncate(Nokogiri::HTML(artefact.details.description).inner_text, length: 200, separator: ' ') %>
       </p>
       <%= link_to("Read more >", artefact.web_url) %>

--- a/app/views/list/tags.html.erb
+++ b/app/views/list/tags.html.erb
@@ -13,7 +13,10 @@
     <li>
     <article class="tag-result">
       <h2><%= link_to(artefact.title, artefact.web_url ) %></h2>
-      <div class="content"><%= raw artefact.details.description %></div>
+      <p>
+      <%= truncate(Nokogiri::HTML(artefact.details.description).inner_text, length: 200, separator: ' ') %>
+      </p>
+      <%= link_to("Read more >", artefact.web_url) %>
       <%= render :partial => "content/tags", locals: {tags: artefact.tags }  %>
     </article>
     </li>

--- a/test/functional/tag_controller_test.rb
+++ b/test/functional/tag_controller_test.rb
@@ -11,7 +11,7 @@ class TagControllerTest < ActionController::TestCase
 
     doc = Nokogiri::HTML response.body
 
-    assert_match doc.search('.content').inner_html, /Established from its inception/
+    assert_match doc.search('.description').inner_html, /Established from its inception/
     assert_match doc.search('.result-count').inner_text, /1 result found/
 
     assert_equal doc.search('.tag-results ul li').count, 1


### PR DESCRIPTION
# What's changed:

* Show the first 200 characters of the description as requested by @langphil, also added a `<p>` wrapper, since it's no longer html content.

![screenshot 2015-04-03 08 08 26](https://cloud.githubusercontent.com/assets/485583/6976766/ad1ba90e-d9d8-11e4-85d1-c10fa6d4c6b4.png)