### PR TITLE
Event namespacing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,7 +63,7 @@ class ApplicationController < ActionController::Base
     url_map = {
       "open-data-challenge-series" => "challenge-series"
     }
-    x = event.details.event_type || "event"
+    x = event.details.event_type.sub(/^event:/,'') || "event"
     url_map[x] || x
   end
   helper_method :event_type

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -613,7 +613,7 @@ class RootController < ApplicationController
   def collect_artefacts(tags)
     artefacts = []
     tags.each do |tag|
-      artefacts += content_api.with_tag(tag).results
+      artefacts += content_api.with_tag(tag).results rescue []
     end
     return artefacts
   end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -122,8 +122,8 @@ class RootController < ApplicationController
 
   def lunchtime_lectures
     @section = 'lunchtime-lectures'
-    @upcoming = collect_events(['lunchtime-lecture'], :upcoming)
-    @previous = collect_events(['lunchtime-lecture'], :previous)
+    @upcoming = collect_events(['lunchtime-lecture', 'event:lunchtime-lecture'], :upcoming)
+    @previous = collect_events(['lunchtime-lecture', 'event:lunchtime-lecture'], :previous)
     @title = "Lunchtime Lectures"
     @publication = fetch_article("lunchtime-lectures", nil, "article")
     respond_to do |format|


### PR DESCRIPTION
Some horrible kludges required to support namespaced event tags. Massively defensively coded. Needs to be done at similar time as panopticon retagging.