### PR TITLE
Summit homepage

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -51,6 +51,7 @@ class RootController < ApplicationController
   end
 
   def summit_speaker_list
+    @year = params[:year]
     @section = params[:section].parameterize
     @artefacts = content_api.sorted_by(@section.dasherize, 'curated').results
     @title = "Summit Speakers"

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -51,8 +51,8 @@ class RootController < ApplicationController
   end
 
   def summit_speaker_list
-    @section = 'summit_speaker'
-    @artefacts = content_api.sorted_by('summit-speaker', 'curated').results
+    @section = params[:section].parameterize
+    @artefacts = content_api.sorted_by(@section.dasherize, 'curated').results
     @title = "Summit Speakers"
     respond_to do |format|
       format.html do
@@ -260,7 +260,7 @@ class RootController < ApplicationController
   end
 
   def summit_speaker_article
-    @publication = fetch_article(params[:slug], params[:edition], params[:section])
+    @publication = fetch_article(params[:slug], params[:edition], 'person')
 
     respond_to do |format|
       format.html do

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -91,6 +91,7 @@ class RootController < ApplicationController
 
   def events_article
     if params[:event_type]
+      @section = "summit" if params[:event_type].to_sym == :summit
       @section = "lunchtime-lectures" if params[:event_type].to_sym == :lunchtime_lectures
       article(params, @section)
     else

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -50,6 +50,20 @@ class RootController < ApplicationController
     end
   end
 
+  def summit_speaker_list
+    @section = 'summit_speaker'
+    @artefacts = content_api.sorted_by('summit-speaker', 'curated').results
+    @title = "Summit Speakers"
+    respond_to do |format|
+      format.html do
+        render "list/summit-speakers-listing"
+      end
+      format.json do
+        redirect_to "#{api_domain}/with_tag.json?tag=summit-speaker"
+      end
+    end
+  end
+
   def case_studies_list
     @section = params[:section].parameterize
     @artefacts = content_api.sorted_by('case_study', 'curated').results

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -268,6 +268,7 @@ class RootController < ApplicationController
   end
 
   def summit_speaker_article
+    @year = params[:year]
     @publication = fetch_article(params[:slug], params[:edition], 'person')
 
     respond_to do |format|

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -103,9 +103,16 @@ class RootController < ApplicationController
     end
   end
 
+  def summit_page
+    @year = params[:year].to_i
+    @section = "summit"
+    summit_pages = YAML.load_file(File.join Rails.root, 'config' , 'summit_pages.yml')
+    params[:slug] = summit_pages[@year]
+    article(params, @section)
+  end
+
   def events_article
     if params[:event_type]
-      @section = "summit" if params[:event_type].to_sym == :summit
       @section = "lunchtime-lectures" if params[:event_type].to_sym == :lunchtime_lectures
       article(params, @section)
     else

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -54,7 +54,7 @@ class RootController < ApplicationController
     @year = params[:year]
     @section = params[:section].parameterize
     @artefacts = content_api.sorted_by(@section.dasherize, 'curated').results
-    @title = "Summit Speakers"
+    @title = "Summit #{@year} Speakers"
     respond_to do |format|
       format.html do
         render "list/summit-speakers-listing"

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -245,6 +245,19 @@ class RootController < ApplicationController
     end
   end
 
+  def summit_speaker_article
+    @publication = fetch_article(params[:slug], params[:edition], params[:section])
+
+    respond_to do |format|
+      format.html do
+        render "content/summit_speaker"
+      end
+      format.json do
+        redirect_to "#{api_domain}/#{params[:slug]}.json"
+      end
+    end
+  end
+
   def start_ups_list
     @publication = fetch_article('start-ups', params[:edition], "article") rescue nil
     list(params)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -121,6 +121,17 @@ module ApplicationHelper
     end
   end
 
+  def speakers(publication)
+    return nil unless publication.format == 'event'
+    publication.artefact['related'].select do |r|
+      r['format'] == 'person'
+    end
+  end
+
+  def person_image(person)
+    person['id'].gsub('.json', '/image?version=square')
+  end
+
   private
 
   def set_og_description content

--- a/app/views/content/_speakers.html.erb
+++ b/app/views/content/_speakers.html.erb
@@ -1,0 +1,43 @@
+<div id="speakers">
+  <ul class="people-team">
+    <% speakers.each do |person| %>
+      <li class="home-module">
+          <div class="module module-light module-colour-8 listing">
+              <a href="<%= person['web_url'] %>">
+                  <%= image_tag 'http://asset-manager.dev/uploads/assets/b1/bd/57b1bd564ea4616bf6000001/michaelbluth.jpg', width: "238", alt: person['title'] %>
+                  <h1 class="module-heading"><%= person['title'] %></h1>
+                  <p class="module-subheading">Description of talk...</p>
+              </a>
+          </div>
+      </li>
+    <% end %>
+  </ul>
+  <p id="all-speakers"><%= link_to "View all", "#" %></p>
+</div>
+
+<hr />
+
+<script>
+$('.people-team').slick({
+  dots: false,
+  infinite: true,
+  speed: 300,
+  slidesToShow: 4,
+  slidesToScroll: 4,
+  prevArrow: null,
+  nextArrow: '<div id="speaker-nav"><i class="fa fa-chevron-right fa-6" aria-hidden="true"></i></div>',
+  responsive: [
+    {
+      breakpoint: 1024,
+      settings: {
+        slidesToShow: 3,
+        slidesToScroll: 3,
+      }
+    },
+    {
+      breakpoint: 768,
+      settings: "unslick"
+    }
+  ]
+});
+</script>

--- a/app/views/content/_speakers.html.erb
+++ b/app/views/content/_speakers.html.erb
@@ -6,7 +6,6 @@
               <a href="<%= send("summit_speaker_#{@year}_article_path", person['slug']) %>">
                   <%= image_tag person_image(person), width: "238", alt: person['title'] %>
                   <h1 class="module-heading"><%= person['title'] %></h1>
-                  <p class="module-subheading">Description of talk...</p>
               </a>
           </div>
       </li>

--- a/app/views/content/_speakers.html.erb
+++ b/app/views/content/_speakers.html.erb
@@ -4,7 +4,7 @@
       <li class="home-module">
           <div class="module module-light module-colour-8 listing">
               <a href="<%= person['web_url'] %>">
-                  <%= image_tag 'http://asset-manager.dev/uploads/assets/b1/bd/57b1bd564ea4616bf6000001/michaelbluth.jpg', width: "238", alt: person['title'] %>
+                  <%= image_tag person_image(person), width: "238", alt: person['title'] %>
                   <h1 class="module-heading"><%= person['title'] %></h1>
                   <p class="module-subheading">Description of talk...</p>
               </a>

--- a/app/views/content/_speakers.html.erb
+++ b/app/views/content/_speakers.html.erb
@@ -3,7 +3,7 @@
     <% speakers.each do |person| %>
       <li class="home-module">
           <div class="module module-light module-colour-8 listing">
-              <a href="<%= person['web_url'] %>">
+              <a href="<%= send("summit_speaker_#{@year}_article_path", person['slug']) %>">
                   <%= image_tag person_image(person), width: "238", alt: person['title'] %>
                   <h1 class="module-heading"><%= person['title'] %></h1>
                   <p class="module-subheading">Description of talk...</p>
@@ -12,7 +12,7 @@
       </li>
     <% end %>
   </ul>
-  <p id="all-speakers"><%= link_to "View all", summit_speaker_list_path %></p>
+  <p id="all-speakers"><%= link_to "View all", send("summit_speaker_#{@year}_list_path") %></p>
 </div>
 
 <hr />

--- a/app/views/content/_speakers.html.erb
+++ b/app/views/content/_speakers.html.erb
@@ -12,7 +12,7 @@
       </li>
     <% end %>
   </ul>
-  <p id="all-speakers"><%= link_to "View all", "#" %></p>
+  <p id="all-speakers"><%= link_to "View all", summit_speaker_list_path %></p>
 </div>
 
 <hr />

--- a/app/views/content/summit.html.erb
+++ b/app/views/content/summit.html.erb
@@ -1,0 +1,18 @@
+<% article_meta @publication %>
+
+<% content_for :title do %>
+  <% if @publication.end_date.to_datetime >= DateTime.now %>
+    <a href="<%= events_section_path %>">Events</a>
+  <% else %>
+    <a href="<%= previous_events_section_path %>">Previous Events</a>
+  <% end %>
+<% end %>
+
+<div class ="article-full">
+	<article class="article-body">
+	  <%= render :partial => 'content/event', :locals => { :publication => @publication, :upcoming_event => @upcoming_event } %>
+    <hr />
+    <h2>Speakers</h2>
+    <%= render :partial => 'content/speakers', :locals => { :speakers => speakers(@publication) } %>
+  </article>
+</div>

--- a/app/views/content/summit_speaker.html.erb
+++ b/app/views/content/summit_speaker.html.erb
@@ -1,0 +1,24 @@
+<% article_meta @publication, :person %>
+
+<% content_for :title do %>
+  <a href="<%= team_section_path %>">Summit Speakers</a>
+<% end %>
+
+<div class="article-main">
+  <article class="people-body">
+    <h2><%= [@publication.honorific_prefix, @publication.title, @publication.honorific_suffix].join(" ") %></h2>
+	  <h3><%= @publication.role %></h3>
+    <%= @publication.description.html_safe %>
+  </article>
+</div>
+
+<aside class="article-sidebar">
+    <div class="module module-image-fullbleed">
+	    <%= image_tag @publication.square_image || 'person-placeholder.png', alt: @publication.title %>
+      <div id="social">
+        <%= content_tag(:a ,fa_icon("linkedin-square 2x"), :href => @publication.linkedin, :title => "LinkedIn") unless @publication.linkedin.blank? %>
+        <%= content_tag(:a , fa_icon("github 2x"), :href => @publication.github, :title => "Github") unless @publication.github.blank? %>
+        <%= content_tag(:a ,fa_icon("twitter 2x"), :href => "http://www.twitter.com/#{@publication.twitter}", :title => "Twitter") unless @publication.twitter.blank? %>
+      </div>
+    </div>
+</aside>

--- a/app/views/content/summit_speaker.html.erb
+++ b/app/views/content/summit_speaker.html.erb
@@ -1,7 +1,7 @@
 <% article_meta @publication, :person %>
 
 <% content_for :title do %>
-  <a href="<%= team_section_path %>">Summit Speakers</a>
+  <a href="<%= send("summit_speaker_#{@year}_list_path") %>">Summit <%= @year %> Speakers</a>
 <% end %>
 
 <div class="article-main">

--- a/app/views/list/_summit_speaker.erb
+++ b/app/views/list/_summit_speaker.erb
@@ -1,0 +1,7 @@
+<ul class="grid effect-2 listing" id="grid2">
+	<% artefacts.each do |artefact| %>
+		<%= render :partial => "list/block", :locals => { :artefact => artefact } %>
+	<% end %>
+</ul>
+
+<%= render :partial => "list/pager", :locals => { :artefacts => artefacts, :page => @page } %>

--- a/app/views/list/summit-speakers-listing.erb
+++ b/app/views/list/summit-speakers-listing.erb
@@ -1,0 +1,15 @@
+<% content_for :title, @title %>
+
+  <ul class="grid effect-2" id="grid-people">
+    <div class="grid-sizer"></div>
+    <% @artefacts.each_with_index do |person| %>
+    <li class="home-module">
+        <div class="module module-light module-colour-8">
+            <a href="<%= person.web_url %>">
+                <%= image_tag person_image(person), width: "238", alt: person.title %>
+                <h1 class="module-heading"><%= person.title %></h1>
+            </a>
+        </div>
+    </li>
+    <% end %>
+  </ul>

--- a/app/views/list/summit-speakers-listing.erb
+++ b/app/views/list/summit-speakers-listing.erb
@@ -1,4 +1,8 @@
-<% content_for :title, @title %>
+<% content_for :title do %>
+  <a href="<%= send("summit_#{@year}_section_path") %>">Summit 2016</a>
+<% end %>
+
+<h2>Speakers</h2>
 
 <div class="people-team">
   <ul class="grid effect-2" id="grid-people">

--- a/app/views/list/summit-speakers-listing.erb
+++ b/app/views/list/summit-speakers-listing.erb
@@ -5,7 +5,7 @@
     <% @artefacts.each_with_index do |person| %>
     <li class="home-module">
         <div class="module module-light module-colour-8">
-            <a href="<%= person.web_url %>">
+            <a href="<%= send("summit_speaker_#{@year}_article_path", person['slug']) %>">
                 <%= image_tag person_image(person), width: "238", alt: person.title %>
                 <h1 class="module-heading"><%= person.title %></h1>
             </a>

--- a/app/views/list/summit-speakers-listing.erb
+++ b/app/views/list/summit-speakers-listing.erb
@@ -1,5 +1,6 @@
 <% content_for :title, @title %>
 
+<div class="people-team">
   <ul class="grid effect-2" id="grid-people">
     <div class="grid-sizer"></div>
     <% @artefacts.each_with_index do |person| %>
@@ -13,3 +14,4 @@
     </li>
     <% end %>
   </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Www::Application.routes.draw do
 
   [2016].each do |year|
     get "summit/#{year}", as: "summit_section", to: "root#summit_page", year: year, section: 'events'
-    get "summit/#{year}/speakers", as: "summit_speaker_#{year}_list", to: 'root#summit_speaker_list', section: "summit_speaker_#{year}"
+    get "summit/#{year}/speakers", as: "summit_speaker_#{year}_list", to: 'root#summit_speaker_list', section: "summit_speaker_#{year}", year: year
     get "summit/#{year}/speakers/:slug", as: "summit_speaker_#{year}_article", to: 'root#summit_speaker_article', section: "summit_speaker_#{year}"
     get ":section_slug/#{summit_pages[year]}", to: redirect("/summit/#{year}")
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Www::Application.routes.draw do
   [2016].each do |year|
     get "summit/#{year}", as: "summit_#{year}_section", to: "root#summit_page", year: year, section: 'events'
     get "summit/#{year}/speakers", as: "summit_speaker_#{year}_list", to: 'root#summit_speaker_list', section: "summit_speaker_#{year}", year: year
-    get "summit/#{year}/speakers/:slug", as: "summit_speaker_#{year}_article", to: 'root#summit_speaker_article', section: "summit_speaker_#{year}"
+    get "summit/#{year}/speakers/:slug", as: "summit_speaker_#{year}_article", to: 'root#summit_speaker_article', section: "summit_speaker_#{year}", year: year
     get ":section_slug/#{summit_pages[year]}", to: redirect("/summit/#{year}")
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,8 @@ Www::Application.routes.draw do
     get "#{slug}", as: "#{section}_section", to: 'root#section', section: slug
   end
 
+  get "summit/speakers/:slug", as: 'summit_speaker_article', to: 'root#summit_speaker_article', section: 'people'
+
   get "courses/:slug/:date", as: 'course_instance', to: 'root#course_instance'
 
   get 'tags/*tag', to: 'tag#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Www::Application.routes.draw do
     get "#{section_slug}/:slug/badge", as: "#{section}_badge", to: 'root#badge', :section => section_slug
   end
 
-  [:lunchtime_lectures, :meetups, :research_afternoons, :challenge_series, :roundtables, :workshops, :networking_events, :panel_discussions].each do |event_type|
+  [:lunchtime_lectures, :meetups, :research_afternoons, :challenge_series, :roundtables, :workshops, :networking_events, :panel_discussions, :summit].each do |event_type|
     section_slug = event_type.to_s.dasherize
 
     get "#{section_slug}", as: "#{event_type}_section", to: "root#events_list", :section => "events", :event_type => event_type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,9 @@ Www::Application.routes.draw do
   get "current-start-ups", as: "start_ups_current_section", to: "root#start_ups_current_list", :section => "start_ups"
   get "graduated-start-ups", as: "start_ups_graduated_section", to: "root#start_ups_graduated_list", :section => "start_ups"
 
+  get "summit/speakers", as: 'summit_speaker_list', to: 'root#summit_speaker_list', section: 'people'
+  get "summit/speakers/:slug", as: 'summit_speaker_article', to: 'root#summit_speaker_article', section: 'people'
+
   [:blog, :news, :jobs, :team, :case_studies, :courses, :creative_works, :start_ups, :nodes, :consultation_responses, :guides, :events, :culture].each do |section|
     section_slug = section.to_s.dasherize
     get "#{section_slug}", as: "#{section}_section", to: "root##{section}_list", :section => section_slug
@@ -58,8 +61,6 @@ Www::Application.routes.draw do
     slug = section.to_s.dasherize
     get "#{slug}", as: "#{section}_section", to: 'root#section', section: slug
   end
-
-  get "summit/speakers/:slug", as: 'summit_speaker_article', to: 'root#summit_speaker_article', section: 'people'
 
   get "courses/:slug/:date", as: 'course_instance', to: 'root#course_instance'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Www::Application.routes.draw do
   summit_pages = YAML.load_file(File.join Rails.root, 'config' , 'summit_pages.yml')
 
   [2016].each do |year|
-    get "summit/#{year}", as: "summit_section", to: "root#summit_page", year: year, section: 'events'
+    get "summit/#{year}", as: "summit_#{year}_section", to: "root#summit_page", year: year, section: 'events'
     get "summit/#{year}/speakers", as: "summit_speaker_#{year}_list", to: 'root#summit_speaker_list', section: "summit_speaker_#{year}", year: year
     get "summit/#{year}/speakers/:slug", as: "summit_speaker_#{year}_article", to: 'root#summit_speaker_article', section: "summit_speaker_#{year}"
     get ":section_slug/#{summit_pages[year]}", to: redirect("/summit/#{year}")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,8 +27,10 @@ Www::Application.routes.draw do
   get "current-start-ups", as: "start_ups_current_section", to: "root#start_ups_current_list", :section => "start_ups"
   get "graduated-start-ups", as: "start_ups_graduated_section", to: "root#start_ups_graduated_list", :section => "start_ups"
 
-  get "summit/speakers", as: 'summit_speaker_list', to: 'root#summit_speaker_list', section: 'people'
-  get "summit/speakers/:slug", as: 'summit_speaker_article', to: 'root#summit_speaker_article', section: 'people'
+  [2016].each do |year|
+    get "summit/#{year}/speakers", as: 'summit_speaker_list', to: 'root#summit_speaker_list', section: "summit_speaker_#{year}"
+    get "summit/#{year}/speakers/:slug", as: 'summit_speaker_article', to: 'root#summit_speaker_article', section: "summit_speaker_#{year}"
+  end
 
   [:blog, :news, :jobs, :team, :case_studies, :courses, :creative_works, :start_ups, :nodes, :consultation_responses, :guides, :events, :culture].each do |section|
     section_slug = section.to_s.dasherize

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,15 +23,19 @@ Www::Application.routes.draw do
   get "lunchtime-lectures", as: "lunchtime_lectures_section", to: "root#lunchtime_lectures"
   get "nodes/news", as: 'node_news', to: 'root#node_news_list'
 
-  # Load variants of start-ups lists
-  get "current-start-ups", as: "start_ups_current_section", to: "root#start_ups_current_list", :section => "start_ups"
-  get "graduated-start-ups", as: "start_ups_graduated_section", to: "root#start_ups_graduated_list", :section => "start_ups"
+  # Summit stuff
+  summit_pages = YAML.load_file(File.join Rails.root, 'config' , 'summit_pages.yml')
 
   [2016].each do |year|
     get "summit/#{year}", as: "summit_section", to: "root#summit_page", year: year, section: 'events'
     get "summit/#{year}/speakers", as: "summit_speaker_#{year}_list", to: 'root#summit_speaker_list', section: "summit_speaker_#{year}"
     get "summit/#{year}/speakers/:slug", as: "summit_speaker_#{year}_article", to: 'root#summit_speaker_article', section: "summit_speaker_#{year}"
+    get ":section_slug/#{summit_pages[year]}", to: redirect("/summit/#{year}")
   end
+
+  # Load variants of start-ups lists
+  get "current-start-ups", as: "start_ups_current_section", to: "root#start_ups_current_list", :section => "start_ups"
+  get "graduated-start-ups", as: "start_ups_graduated_section", to: "root#start_ups_graduated_list", :section => "start_ups"
 
   [:blog, :news, :jobs, :team, :case_studies, :courses, :creative_works, :start_ups, :nodes, :consultation_responses, :guides, :events, :culture].each do |section|
     section_slug = section.to_s.dasherize

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,9 @@ Www::Application.routes.draw do
   get "graduated-start-ups", as: "start_ups_graduated_section", to: "root#start_ups_graduated_list", :section => "start_ups"
 
   [2016].each do |year|
-    get "summit/#{year}/speakers", as: 'summit_speaker_list', to: 'root#summit_speaker_list', section: "summit_speaker_#{year}"
-    get "summit/#{year}/speakers/:slug", as: 'summit_speaker_article', to: 'root#summit_speaker_article', section: "summit_speaker_#{year}"
+    get "summit/#{year}", as: "summit_section", to: "root#summit_page", year: year, section: 'events'
+    get "summit/#{year}/speakers", as: "summit_speaker_#{year}_list", to: 'root#summit_speaker_list', section: "summit_speaker_#{year}"
+    get "summit/#{year}/speakers/:slug", as: "summit_speaker_#{year}_article", to: 'root#summit_speaker_article', section: "summit_speaker_#{year}"
   end
 
   [:blog, :news, :jobs, :team, :case_studies, :courses, :creative_works, :start_ups, :nodes, :consultation_responses, :guides, :events, :culture].each do |section|
@@ -45,7 +46,7 @@ Www::Application.routes.draw do
     get "#{section_slug}/:slug/badge", as: "#{section}_badge", to: 'root#badge', :section => section_slug
   end
 
-  [:lunchtime_lectures, :meetups, :research_afternoons, :challenge_series, :roundtables, :workshops, :networking_events, :panel_discussions, :summit].each do |event_type|
+  [:lunchtime_lectures, :meetups, :research_afternoons, :challenge_series, :roundtables, :workshops, :networking_events, :panel_discussions].each do |event_type|
     section_slug = event_type.to_s.dasherize
 
     get "#{section_slug}", as: "#{event_type}_section", to: "root#events_list", :section => "events", :event_type => event_type

--- a/config/summit_pages.yml
+++ b/config/summit_pages.yml
@@ -1,0 +1,1 @@
+2016: 'odi-summit-and-awards-2016'


### PR DESCRIPTION
This does a whole bunch of changes around the Summit. 

* Each summit now has a homepage - the 2016 will be at /summit/2016 - this is done by editing a YAML file, which maps the year to the slug \*
* The summit page will now have a list of speakers, like so:
![download 4](https://cloud.githubusercontent.com/assets/109774/17705129/35aafcb2-63cf-11e6-9e8f-a12ce739bc31.png)
This is achieved by creating a new Person artefact with a type `summit-speaker-2016`, and applying it to the Summit page as a related article
* There is also a page that lists all the speakers, as well as a page for each speaker

\* This is less messy than the original suggestion of changing the slug, and also allows us to pass the year for use later in the template to build the speaker pages

There's still stuff to do around Summit sessions, but this is a step forward, so probably good to merge 👍 