### PR TITLE
Hide sessions from events page

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -648,6 +648,7 @@ class RootController < ApplicationController
       artefacts.reject!{|x| Date.parse(x.details.start_date || x.details.date) < Date.today}
       artefacts.sort_by!{|x| Date.parse(x.details.start_date || x.details.date)}
     end
+    artefacts.reject! { |a| a.tag_ids.select { |t| t.match(/session/) }.count > 0 }
     return artefacts
   end
 


### PR DESCRIPTION
Other than adding the Tag to the live database, this is pretty much all we need to do, particularly if we're hand building the pages