### PR TITLE
Move speakers

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -648,6 +648,7 @@ class RootController < ApplicationController
       artefacts.reject!{|x| Date.parse(x.details.start_date || x.details.date) < Date.today}
       artefacts.sort_by!{|x| Date.parse(x.details.start_date || x.details.date)}
     end
+    artefacts.reject! { |a| a.tag_ids.select { |t| t.match(/session/) }.count > 0 }
     return artefacts
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -139,6 +139,18 @@ module ApplicationHelper
     image_tag "http://contentapi.theodi.org/#{author['slug']}/image?version=square", alt: author['name'], size: "50x50"
   end
 
+  def summit_speakers(publication)
+    body = """
+      <hr />
+      <h2>Speakers</h2>
+    """
+    body << render(:partial => 'content/speakers', :locals => { :speakers => speakers(publication) })
+  end
+
+  def summit_description(publication)
+    publication.description.gsub(/^.+\[speakers\].+$/, summit_speakers(publication)).html_safe
+  end
+
   private
 
   def set_og_description content

--- a/app/views/content/_speakers.html.erb
+++ b/app/views/content/_speakers.html.erb
@@ -14,8 +14,6 @@
   <p id="all-speakers"><%= link_to "View all", send("summit_speaker_#{@year}_list_path") %></p>
 </div>
 
-<hr />
-
 <script>
 $('.people-team').slick({
   dots: false,

--- a/app/views/content/_summit.html.erb
+++ b/app/views/content/_summit.html.erb
@@ -1,0 +1,9 @@
+<h2><%= publication.title %></h2>
+<h3><%= date_range DateTime.parse(publication.start_date), DateTime.parse(publication.end_date) %></h3>
+
+<p><%= publication.location %></p>
+<%= summit_description(publication) %>
+
+<% if upcoming_event? %>
+  <p><%= link_to "More information and to book your place", publication.booking_url if publication.booking_url.present? %></p>
+<% end %>

--- a/app/views/content/summit.html.erb
+++ b/app/views/content/summit.html.erb
@@ -10,9 +10,6 @@
 
 <div class ="article-full">
 	<article class="article-body">
-	  <%= render :partial => 'content/event', :locals => { :publication => @publication, :upcoming_event => @upcoming_event } %>
-    <hr />
-    <h2>Speakers</h2>
-    <%= render :partial => 'content/speakers', :locals => { :speakers => speakers(@publication) } %>
+	  <%= render :partial => 'content/summit', :locals => { :publication => @publication, :upcoming_event => @upcoming_event } %>
   </article>
 </div>


### PR DESCRIPTION
This adds support to the summit page to add the speakers partial to wherever a `[speakers]` tag is placed on the page